### PR TITLE
Feature Improvements and Bug Fixes (Try #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ a2n = Air2Neo(
         # which is a pyairtable.Table object.
 
         name_col,                           # "Name",
+        view_col,                           # "View", (optional)
         index_for_col,                      # "IndexFor",
         constrain_for_col,                  # "ConstrainFor",
         node_properties_col,                # "NodeProperties",

--- a/air2neo/main.py
+++ b/air2neo/main.py
@@ -497,7 +497,6 @@ class Air2Neo:
 
         self.logger.info("Validating Airtable to Neo4j ingest job...")
         self.metatable_config.validate()
-
         self.logger.info("✨ Validation OK")
 
         self.create_indices_from_metatable()

--- a/air2neo/neo4j_operations.py
+++ b/air2neo/neo4j_operations.py
@@ -93,15 +93,15 @@ def neo4jop_batch_create_edge(
         f"OPTIONAL MATCH (n)-[rel]-(m) "
         f"WITH n, m, edge, COLLECT(TYPE(rel)) AS relTypes "
         f"WHERE NOT edge[2] IN relTypes "
-        f"CALL apoc.create.relationship(n, edge[2], NULL, m)\n",
-        f"YIELD rel\",\n"
+        f"CALL apoc.create.relationship(n, edge[2], {{}}, m) YIELD rel RETURN COUNT(rel) as num_relationships_created\",\n"
         f"{{batchSize: {batch_size}, "
         f"parallel: {str(parallel).lower()}, "
         f"iterateList: {str(iterateList).lower()}, "
         f"params: {{edge_list: $edge_list}}"
         f"}})\n"
-        # f"YIELD batch\n"
-        f"RETURN batch"
+        f"YIELD batches, total\n"
+        f"RETURN batches, total"
     )
     res = tx.run(cypher, edge_list=edge_list)
+    print(edge_list)
     return res

--- a/air2neo/neo4j_operations.py
+++ b/air2neo/neo4j_operations.py
@@ -9,7 +9,6 @@ def neo4jop_batch_create_nodes(
     node_list: Sequence[Dict[str, Any]],
     *,
     id_property: str = "_aid",
-    batch_size: int = 1000,
 ) -> Result:
     """Creates a batch of nodes.
 
@@ -23,13 +22,8 @@ def neo4jop_batch_create_nodes(
         f"MERGE (n:`{label}` {{ {id_property}: node.{id_property} }}) "
         f"SET n = node"
     )
-
-    # Split node_list into batches
-    for i in range(0, len(node_list), batch_size):
-        batch = node_list[i : i + batch_size]
-        tx.run(cypher, node_list=batch)
-        
-    return tx.commit()
+    res = tx.run(cypher, node_list=node_list)
+    return res
 
 
 def neo4jop_create_constraint_for_label(

--- a/air2neo/neo4j_operations.py
+++ b/air2neo/neo4j_operations.py
@@ -103,5 +103,5 @@ def neo4jop_batch_create_edge(
         f"RETURN batches, total"
     )
     res = tx.run(cypher, edge_list=edge_list)
-    print(edge_list)
+    #print(edge_list)
     return res

--- a/air2neo/neo4j_operations.py
+++ b/air2neo/neo4j_operations.py
@@ -9,6 +9,7 @@ def neo4jop_batch_create_nodes(
     node_list: Sequence[Dict[str, Any]],
     *,
     id_property: str = "_aid",
+    batch_size: int = 1000,
 ) -> Result:
     """Creates a batch of nodes.
 
@@ -22,8 +23,13 @@ def neo4jop_batch_create_nodes(
         f"MERGE (n:`{label}` {{ {id_property}: node.{id_property} }}) "
         f"SET n = node"
     )
-    res = tx.run(cypher, node_list=node_list)
-    return res
+
+    # Split node_list into batches
+    for i in range(0, len(node_list), batch_size):
+        batch = node_list[i : i + batch_size]
+        tx.run(cypher, node_list=batch)
+        
+    return tx.commit()
 
 
 def neo4jop_create_constraint_for_label(


### PR DESCRIPTION
* Added support to sync only Airtable records within a specified view (optional)
* Added support to sync only specific Airtable fields as specified in the NodeProperties (significantly speeds up syncs on very large tables)
* During edge creation, added temporary _counters node to keep track of how many edges were successfully created, skipped, or unable to be created because either the source_id or target_id were missing from the Neo4J graph (helps troubleshooting syncs with large Airtable tables)
* Also fixed Issue #8 